### PR TITLE
preview

### DIFF
--- a/src/Components/App/App.js
+++ b/src/Components/App/App.js
@@ -63,10 +63,11 @@ class App extends React.Component {
   }
  
   handlePlayPreview(preview_url) {
-    handlePlayPreview  = props.searchResult.tracklist.track;
+
+    // handlePlayPreview  = props.searchResult.tracklist.track;
 
     this.audio.src=preview_url
-      this.audio.play();
+    this.audio.play();
   }
  
   render() {
@@ -77,7 +78,9 @@ class App extends React.Component {
     <SearchBar onSearch={this.search} /> 
     <div className="App-playlist">
       <SearchResults searchResults={this.state.searchResults}
-        onAdd={this.addTrack} /> 
+        onAdd={this.addTrack}
+        handlePlayPreview = {this.handlePlayPreview}
+         /> 
       <Playlist playstName={this.state.playlistName}
         playlistTracks={this.state.playlistTracks} 
         onRemove = {this.removeTrack}

--- a/src/Components/SearchResults/SearchResults.js
+++ b/src/Components/SearchResults/SearchResults.js
@@ -10,7 +10,8 @@ class SearchResults extends React.Component {
                 <h2>Results</h2>
                 <TrackList tracks ={this.props.searchResults}
                             onAdd={this.props.onAdd}
-                            isRemoval={false} />
+                            isRemoval={false}
+                            handlePlayPreview={this.props.handlePlayPreview} />
             </div>
         )
     }

--- a/src/Components/Track/Track.js
+++ b/src/Components/Track/Track.js
@@ -23,7 +23,7 @@ import playlogo from './playButton.png';
 
     previewTrack() {
         if(this.props.track.preview) {
-            return <button className="play-action" onClick={this.audioPreview} >
+            return <button className="play-action" onClick={() => this.props.handlePlayPreview(this.props.track.preview)} >
                 <img alt="play button for music" src={playlogo} />
                 </button>
         }
@@ -39,10 +39,11 @@ import playlogo from './playButton.png';
         this.props.onRemove(this.props.track);
     }
 
-    audioPreview = () => {
-      const audio = new Audio(this.props.track.preview)
-      audio.play();
-    }
+    // audioPreview = () => {
+    //   const audio = new Audio(this.props.track.preview)
+    //   audio.play();
+    // }
+    // logic will be handle by handlePlayPreview in app.js
 
    
 

--- a/src/Components/TrackList/TrackList.js
+++ b/src/Components/TrackList/TrackList.js
@@ -12,7 +12,8 @@ class TrackList extends React.Component {
                         key ={track.id} 
                         onAdd={this.props.onAdd}
                         onRemove= {this.props.onRemove}
-                        isRemovel ={this.props.isRemoval} />
+                        isRemovel ={this.props.isRemoval}
+                        handlePlayPreview={this.props.handlePlayPreview} />
                 })
             }
 </div>


### PR DESCRIPTION
I change a bit in app, searchResults, tracklist and track. I'm not sure how to explain it clearly, you could review the lesson where they show you how to pass state/function to nested components.

In apps, this one looks a bit weird to me (I'm not sure if you can do it like that):

in function handlePlayPreview(preview_url):
handlePlayPreview  = props.searchResult.tracklist.track;
==> Moved this to <searchResults/>

Anyway, I think it'll be easier if we talk. So let me know if you want to clarify any point.
